### PR TITLE
Important hash-related optimizations and cleanups:

### DIFF
--- a/SipHash-tofino/p4src/halfsiphash24_ingressonly.p4
+++ b/SipHash-tofino/p4src/halfsiphash24_ingressonly.p4
@@ -296,14 +296,12 @@ control SwitchIngress(
 		hdr.udp.dst_port=SIP_PORT+1;
 	}
 
-	Hash<bit<32>>(HashAlgorithm_t.IDENTITY) copy32_output;
 	action do_not_recirc(){
 		route_to((bit<9>)hdr.sip_meta.dest_port);
 		hdr.udp.dst_port=SIP_PORT;
-		bit<32> hash_output = hdr.sip_meta.v_0 ^ hdr.sip_meta.v_1 ^ hdr.sip_meta.v_2 ^ hdr.sip_meta.v_3;
 		#define writeout_m(i) hdr.sip.m_##i = 0;
 		__LOOP(NUM_WORDS,writeout_m)
-		hdr.sip.m_0=copy32_output.get({hash_output});
+		@in_hash { hdr.sip.m_0 = hdr.sip_meta.v_0 ^ hdr.sip_meta.v_1 ^ hdr.sip_meta.v_2 ^ hdr.sip_meta.v_3; }
 		hdr.sip_meta.setInvalid();
 	}
 
@@ -333,12 +331,6 @@ control SwitchIngress(
 		hdr.sip_meta.v_2 = key_0 ^ const_2;
 		hdr.sip_meta.v_3 = key_1 ^ const_3;
 	}
-	Hash<bit<32>>(HashAlgorithm_t.IDENTITY) copy32_a_1;
-	Hash<bit<32>>(HashAlgorithm_t.IDENTITY) copy32_a_3;
-	Hash<bit<32>>(HashAlgorithm_t.IDENTITY) copy32_b_0;
-	Hash<bit<32>>(HashAlgorithm_t.IDENTITY) copy32_c_1;
-	Hash<bit<32>>(HashAlgorithm_t.IDENTITY) copy32_c_3;
-	Hash<bit<32>>(HashAlgorithm_t.IDENTITY) copy32_d_2;
 
 	#define MSG_VAR ig_md.sip_tmp.i_0
 	action sip_1_odd(){
@@ -352,11 +344,11 @@ control SwitchIngress(
 		//a_2 = i_2 + i_3
 		ig_md.sip_tmp.a_2 = hdr.sip_meta.v_2 + hdr.sip_meta.v_3;
 		//a_1 = i_1 << 5
-		ig_md.sip_tmp.a_1 = copy32_a_1.get({hdr.sip_meta.v_1[26:0] ++ hdr.sip_meta.v_1[31:27]});
+		@in_hash { ig_md.sip_tmp.a_1 = hdr.sip_meta.v_1[26:0] ++ hdr.sip_meta.v_1[31:27]; }
 	}
 	action sip_1_b(){
 		//a_3 = i_3 << 8
-		ig_md.sip_tmp.a_3 = copy32_a_3.get({hdr.sip_meta.v_3[23:0] ++ hdr.sip_meta.v_3[31:24]});
+		ig_md.sip_tmp.a_3 = hdr.sip_meta.v_3[23:0] ++ hdr.sip_meta.v_3[31:24];
 
 	}
 	action sip_2_a(){
@@ -365,7 +357,7 @@ control SwitchIngress(
 		//b_3 = a_3 ^ a_2
 		ig_md.sip_tmp.i_3 = ig_md.sip_tmp.a_3 ^ ig_md.sip_tmp.a_2;
 		//b_0 = a_0 << 16
-		ig_md.sip_tmp.i_0 = copy32_b_0.get({ig_md.sip_tmp.a_0[15:0] ++ ig_md.sip_tmp.a_0[31:16]});
+		ig_md.sip_tmp.i_0 = ig_md.sip_tmp.a_0[15:0] ++ ig_md.sip_tmp.a_0[31:16];
 		//b_2 = a_2
 		ig_md.sip_tmp.i_2 = ig_md.sip_tmp.a_2;
 	}
@@ -376,11 +368,11 @@ control SwitchIngress(
 		//c_0 = b_0 + b_3
 		ig_md.sip_tmp.a_0 = ig_md.sip_tmp.i_0 + ig_md.sip_tmp.i_3;
 		//c_1 = b_1 << 13
-		ig_md.sip_tmp.a_1 = copy32_c_1.get({ig_md.sip_tmp.i_1[18:0] ++ ig_md.sip_tmp.i_1[31:19]});
+		@in_hash { ig_md.sip_tmp.a_1 = ig_md.sip_tmp.i_1[18:0] ++ ig_md.sip_tmp.i_1[31:19]; }
 	}
 	action sip_3_b(){
 		//c_3 = b_3 << 7
-		ig_md.sip_tmp.a_3 = copy32_c_3.get({ig_md.sip_tmp.i_3[24:0] ++ ig_md.sip_tmp.i_3[31:25]});
+		@in_hash { ig_md.sip_tmp.a_3 = ig_md.sip_tmp.i_3[24:0] ++ ig_md.sip_tmp.i_3[31:25]; }
 	}
 
 	action sip_4_a(){
@@ -389,7 +381,7 @@ control SwitchIngress(
 		//d_3 = c_3 ^ c_0 i
 		hdr.sip_meta.v_3 = ig_md.sip_tmp.a_3 ^ ig_md.sip_tmp.a_0;
 		//d_2 = c_2 << 16
-		hdr.sip_meta.v_2 = copy32_d_2.get({ig_md.sip_tmp.a_2[15:0] ++ ig_md.sip_tmp.a_2[31:16]});
+		hdr.sip_meta.v_2 = ig_md.sip_tmp.a_2[15:0] ++ ig_md.sip_tmp.a_2[31:16];
 
 	}
 	action sip_4_b_odd(){


### PR DESCRIPTION
1. Replaced hash-based 8-, 16- and 24-bit circular shifts (rotations) with the PHV ALU-based ones. As a result the hash unit usage has been significantly reduced, freeing them for other tasks.
2. Replaced explicit `Hash()` extern instantiations and usage with `@in_hash` annotation (available in SDE-9.6.0 and later) to make the code more readable.